### PR TITLE
Fix crash on malformed history Issue-17

### DIFF
--- a/topalias/aliascore.py
+++ b/topalias/aliascore.py
@@ -182,7 +182,9 @@ def load_command_bank(filtering=False):  # pylint: disable=too-many-branches
     history_file_path = find_history()
     try:
         with io.FileIO(r"{}".format(history_file_path), "r") as history_data:
-            history_data_encoded = io.TextIOWrapper(history_data, encoding="UTF-8", errors='ignore')
+            history_data_encoded = io.TextIOWrapper(
+                history_data, encoding="UTF-8", errors="ignore"
+            )
             for line in history_data_encoded:
                 if HISTORY_FILE == ".bash_history":
                     if (not line.startswith("#", 0, 1)) and line != "":

--- a/topalias/aliascore.py
+++ b/topalias/aliascore.py
@@ -182,7 +182,7 @@ def load_command_bank(filtering=False):  # pylint: disable=too-many-branches
     history_file_path = find_history()
     try:
         with io.FileIO(r"{}".format(history_file_path), "r") as history_data:
-            history_data_encoded = io.TextIOWrapper(history_data, encoding="UTF-8")
+            history_data_encoded = io.TextIOWrapper(history_data, encoding="UTF-8", errors='ignore')
             for line in history_data_encoded:
                 if HISTORY_FILE == ".bash_history":
                     if (not line.startswith("#", 0, 1)) and line != "":

--- a/topalias/aliascore.py
+++ b/topalias/aliascore.py
@@ -183,7 +183,7 @@ def load_command_bank(filtering=False):  # pylint: disable=too-many-branches
     try:
         with io.FileIO(r"{}".format(history_file_path), "r") as history_data:
             history_data_encoded = io.TextIOWrapper(
-                history_data, encoding="UTF-8", errors="ignore"
+                history_data, encoding="UTF-8", errors="ignore",
             )
             for line in history_data_encoded:
                 if HISTORY_FILE == ".bash_history":

--- a/topalias/aliascore.py
+++ b/topalias/aliascore.py
@@ -183,7 +183,9 @@ def load_command_bank(filtering=False):  # pylint: disable=too-many-branches
     try:
         with io.FileIO(r"{}".format(history_file_path), "r") as history_data:
             history_data_encoded = io.TextIOWrapper(
-                history_data, encoding="UTF-8", errors="ignore",
+                history_data,
+                encoding="UTF-8",
+                errors="ignore",
             )
             for line in history_data_encoded:
                 if HISTORY_FILE == ".bash_history":


### PR DESCRIPTION
On some history files, I suspect, with russian characters, program crashed with the following stack:

python topalias/cli.py -z
topalias - linux bash/zsh alias generator & history analytics https://github.com/CSRedRat/topalias
File .bash_aliases not found in any of the directories
<_io.FileIO name='/Users/moroz/.zsh_history' mode='rb' closefd=True>
Multiline command in history will be supported in next release
Multiline command in history will be supported in next release
Traceback (most recent call last):
  File "topalias/cli.py", line 159, in <module>
    sys.exit(cli())  # pragma: no cover # pylint: disable=no-value-for-parameter
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 1236, in invoke
    return Command.invoke(self, ctx)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "topalias/cli.py", line 109, in cli
    return ctx.invoke(main)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "topalias/cli.py", line 129, in main
    ctx.forward(top_history)  # pylint: disable=no-value-for-parameter
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 628, in forward
    return self.invoke(cmd, **kwargs)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/moroz/.pyenv/versions/topalias/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "topalias/cli.py", line 150, in top_history
    core.print_history(acronym_minimal_length),
  File "/Users/moroz/Projects/topalias/topalias/aliascore.py", line 229, in print_history
    command_bank = load_command_bank(filtering=ALIASES_FILTER)
  File "/Users/moroz/Projects/topalias/topalias/aliascore.py", line 187, in load_command_bank
    for line in history_data_encoded:
  File "/Users/moroz/.pyenv/versions/3.8.3/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa6 in position 2629: invalid start byte

